### PR TITLE
Rename Friend Tracker to Colaborador Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Friend Tracker for Obsidian
+# Colaborador Tracker for Obsidian
 
 A plugin for Obsidian that helps you keep track of friends, family, and your interactions with them. Never forget a birthday or important detail about someone you care about.
 
@@ -11,7 +11,7 @@ This plugin was inspired by [Scott Stockdale's article on maintaining meaningful
 -   Remembering personal details
 -   Making regular meaningful touchpoints
 
-Friend Tracker helps implement these relationship-building practices in a simple, organized way within Obsidian.
+Colaborador Tracker helps implement these relationship-building practices in a simple, organized way within Obsidian.
 
 ![image](https://github.com/user-attachments/assets/0f8ef3de-6c18-4813-a87a-1a7d5d1a680f)
 
@@ -62,7 +62,7 @@ Friend Tracker helps implement these relationship-building practices in a simple
 
 1. Open Obsidian Settings
 2. Go to Community Plugins and disable Safe Mode
-3. Click Browse and search for "Friend Tracker"
+3. Click Browse and search for "Colaborador Tracker"
 4. Install the plugin and enable it
 
 ## Storage

--- a/locales/en.ini
+++ b/locales/en.ini
@@ -1,4 +1,4 @@
-friend_tracker=Friend tracker
+friend_tracker=Colaborador Tracker
 search_placeholder=Search...
 add_contact=Add contact
 no_contacts=No contacts found. Get started by creating your first contact!

--- a/locales/pt.ini
+++ b/locales/pt.ini
@@ -1,4 +1,4 @@
-friend_tracker=Rastreador de Amigos
+friend_tracker=Colaborador Tracker
 search_placeholder=Pesquisar...
 add_contact=Adicionar contato
 no_contacts=Nenhum contato encontrado. Comece criando seu primeiro contato!

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "friend-tracker",
-	"name": "Friend Tracker",
+        "name": "Colaborador Tracker",
        "version": "1.3.4",
 	"minAppVersion": "1.4.14",
 	"description": "Keep track of friends, birthdays, reminders, and interactions in Obsidian. Build a personal CRM, log connections, and stay organized inside your vault.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,8 +45,8 @@ export default class FriendTracker extends Plugin {
 				(leaf) => new ContactPageView(leaf, this)
 			);
 
-			// Add ribbon icon
-			this.addRibbonIcon("user", "Open friend tracker", async () => {
+                        // Add ribbon icon
+                        this.addRibbonIcon("user", "Open Colaborador Tracker", async () => {
 				const workspace = this.app.workspace;
 				const leaves = workspace.getLeavesOfType(
 					VIEW_TYPE_FRIEND_TRACKER
@@ -68,8 +68,8 @@ export default class FriendTracker extends Plugin {
 						active: true,
 					});
 					workspace.revealLeaf(leaf);
-				} else {
-					new Notice("Could not create Friend Tracker view");
+                                } else {
+                                        new Notice("Could not create Colaborador Tracker view");
 				}
 			});
 
@@ -79,8 +79,8 @@ export default class FriendTracker extends Plugin {
 			// Check for birthdays after everything is initialized
 			await this.checkBirthdays();
 		} catch (error) {
-			console.error("Friend Tracker failed to load:", error);
-			new Notice("Friend Tracker failed to load: " + error.message);
+                        console.error("Colaborador Tracker failed to load:", error);
+                        new Notice("Colaborador Tracker failed to load: " + error.message);
 		}
 	}
 

--- a/src/modals/AddContactModal.ts
+++ b/src/modals/AddContactModal.ts
@@ -151,7 +151,7 @@ export class AddContactModal extends Modal {
 			// Wait a moment for the file to be indexed
 			await new Promise((resolve) => setTimeout(resolve, 300));
 
-			// Refresh the Friend Tracker view
+                        // Refresh the Colaborador Tracker view
 			const friendTrackerLeaves = this.app.workspace.getLeavesOfType(
 				VIEW_TYPE_FRIEND_TRACKER
 			);

--- a/src/services/ContactOperations.ts
+++ b/src/services/ContactOperations.ts
@@ -11,7 +11,7 @@ export class ContactOperations {
 		const folderPath = vault.getFolderByPath(folder);
 
 		if (!folderPath) {
-			new Notice("Friend Tracker folder not found.");
+                        new Notice("Colaborador Tracker folder not found.");
 			return [];
 		}
 

--- a/src/views/ContactPageView/index.ts
+++ b/src/views/ContactPageView/index.ts
@@ -320,7 +320,7 @@ export class ContactPageView extends ItemView {
 						);
                                                 new Notice(this.plugin.t("updated_contact_name"));
 
-						// Refresh Friend Tracker view
+                                                // Refresh Colaborador Tracker view
 						const friendTrackerLeaves =
 							this.app.workspace.getLeavesOfType(
 								VIEW_TYPE_FRIEND_TRACKER

--- a/src/views/FriendTrackerView/index.ts
+++ b/src/views/FriendTrackerView/index.ts
@@ -85,9 +85,9 @@ export class FriendTrackerView extends ItemView {
 		return VIEW_TYPE_FRIEND_TRACKER;
 	}
 
-	getDisplayText(): string {
-		return "Friend tracker";
-	}
+        getDisplayText(): string {
+                return "Colaborador Tracker";
+        }
 
 	async onOpen() {
 		this.registerEvent(


### PR DESCRIPTION
## Summary
- rename plugin text references from Friend Tracker to Colaborador Tracker
- update English and Portuguese translations
- adjust manifest and plugin UI messages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863d3474dd0832f80affb90230f3099