### PR TITLE
Fix view duplication and bundle locales

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,5 @@ jobs:
                   gh release create "$tag" \
                     --title="$tag" \
                     --draft \
-                    main.js manifest.json styles.css
+                    main.js manifest.json styles.css \
+                    locales/en.ini locales/ja.ini locales/pt.ini locales/zh.ini


### PR DESCRIPTION
## Summary
- prevent registering duplicate views
- add translation fallback to bundled locale files
- include locale files in release workflow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863ea9d8018832f9eb08c565c0a47ed